### PR TITLE
V6.0.0 hunter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,7 +303,7 @@ add_library(stdlib STATIC static_libs/chaiscript_stdlib.cpp)
 add_library(parser STATIC static_libs/chaiscript_parser.cpp)
 
 add_library(chaiscript_stdlib-${CHAI_VERSION} MODULE src/chaiscript_stdlib_module.cpp)
-target_link_libraries(chaiscript_stdlib-${CHAI_VERSION} ${LIBS} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(chaiscript_stdlib-${CHAI_VERSION} ${LIBS} Threads::Threads)
 
 set(CHAISCRIPT_LIBS stdlib parser)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,8 +302,12 @@ set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} ${LINKER_FLAGS}")
 add_library(stdlib STATIC static_libs/chaiscript_stdlib.cpp)
 add_library(parser STATIC static_libs/chaiscript_parser.cpp)
 
-add_library(chaiscript_stdlib-${CHAI_VERSION} MODULE src/chaiscript_stdlib_module.cpp)
-target_link_libraries(chaiscript_stdlib-${CHAI_VERSION} ${LIBS} Threads::Threads)
+add_library(chaiscript MODULE src/chaiscript_stdlib_module.cpp)
+set_target_properties(chaiscript PROPERTIES 
+                                 OUTPUT_NAME chaiscript_stdlib-${CHAI_VERSION}
+                     )
+target_link_libraries(chaiscript ${LIBS} Threads::Threads)
+
 
 set(CHAISCRIPT_LIBS stdlib parser)
 
@@ -519,7 +523,7 @@ if(BUILD_TESTING)
   endif()
 endif()
 
-install(TARGETS chai chaiscript_stdlib-${CHAI_VERSION} ${MODULES} RUNTIME DESTINATION bin LIBRARY DESTINATION lib/chaiscript)
+install(TARGETS chai chaiscript ${MODULES} RUNTIME DESTINATION bin LIBRARY DESTINATION lib/chaiscript)
 
 install(DIRECTORY include/chaiscript DESTINATION include
   PATTERN "*.hpp"
@@ -545,7 +549,7 @@ install(FILES "${chaiscript_BINARY_DIR}/lib/pkgconfig/chaiscript.pc"
 ENDIF()
 
 install(
-    TARGETS ${CHAISCRIPT_LIBS} ${MODULES} 
+    TARGETS ${CHAISCRIPT_LIBS} ${MODULES} chaiscript
     EXPORT "${TARGETS_EXPORT_NAME}" 
     ARCHIVE  DESTINATION "lib"
     LIBRARY  DESTINATION "lib"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -551,6 +551,7 @@ install(FILES "${chaiscript_BINARY_DIR}/lib/pkgconfig/chaiscript.pc"
 
 ENDIF()
 
+message("Installing libs: ${CHAISCRIPT_LIBS} and modules: ${MODULES}")
 install(
     TARGETS ${CHAISCRIPT_LIBS} ${MODULES} chaiscript
     EXPORT "${TARGETS_EXPORT_NAME}" 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,6 @@ ELSE()
 
 project(chaiscript VERSION 6.0.0)
 
-
 set(TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
 set(namespace "${PROJECT_NAME}::")
 
@@ -31,10 +30,7 @@ set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
 
 set(version_config "${generated_dir}/${PROJECT_NAME}-configVersion.cmake")
 set(project_config "${generated_dir}/${PROJECT_NAME}-config.cmake")
-set(TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
-set(namespace "${PROJECT_NAME}::")
 
-include(CMakePackageConfigHelpers)
 
 # Use:
 #   * PROJECT_VERSION
@@ -178,6 +174,10 @@ if(NOT MINGW)
   find_library(READLINE_LIBRARY NAMES readline PATH /usr/lib /usr/local/lib /opt/local/lib)
 endif()
 
+if (UNIX)
+   find_package(Threads REQUIRED)
+endif()
+
 if (UNIX AND NOT APPLE)
   find_program(VALGRIND NAMES valgrind PATH /usr/bin /usr/local/bin)
 endif()
@@ -274,7 +274,7 @@ endif()
 
 if(CMAKE_HOST_UNIX)
   if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD" AND NOT ${CMAKE_SYSTEM_NAME} MATCHES "Haiku")
-    list(APPEND LIBS "dl")
+    list(APPEND LIBS ${CMAKE_DL_LIBS})
   endif()
 
   if(MULTITHREAD_SUPPORT_ENABLED)
@@ -289,7 +289,6 @@ if(CMAKE_HOST_UNIX)
       set(LINKER_FLAGS "${LINKER_FLAGS} -pthread")
     endif()
 
-    add_definitions(-pthread)
   endif()
 
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -306,7 +306,10 @@ add_library(chaiscript MODULE src/chaiscript_stdlib_module.cpp)
 set_target_properties(chaiscript PROPERTIES 
                                  OUTPUT_NAME chaiscript_stdlib-${CHAI_VERSION}
                      )
-target_link_libraries(chaiscript ${LIBS} Threads::Threads)
+target_link_libraries(chaiscript ${LIBS})
+if ( !CMAKE_HOST_WIN32 )
+    target_link_libraries(chaiscript Threads::Threads)
+endif()
 
 
 set(CHAISCRIPT_LIBS stdlib parser)

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -2,6 +2,7 @@
 
 if ( CMAKE_HOST_UNIX AND NOT MINGW ) 
     find_package(Threads REQUIRED)
+    message("Using threads: " Threads::Threads)
     list(APPEND libs Threads::Threads)
     list(APPEND libs ${CMAKE_DL_LIBS})
 endif() 

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -2,7 +2,7 @@
 
 if ( CMAKE_HOST_UNIX AND NOT MINGW ) 
     find_package(Threads REQUIRED)
-    list(APPEND libs Thread::Threads)
+    list(APPEND libs Threads::Threads)
     list(APPEND libs ${CMAKE_DL_LIBS})
 endif() 
 

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -2,8 +2,6 @@
 
 if ( CMAKE_HOST_UNIX AND NOT MINGW ) 
     find_package(Threads REQUIRED)
-    add_library(Threads::Threads)
-    add_library(${CMAKE_DL_LIBS})
 endif() 
 
 include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,2 +1,9 @@
 @PACKAGE_INIT@
+
+if ( CMAKE_HOST_UNIX AND NOT MINGW ) 
+    find_package(Threads REQUIRED)
+    list(APPEND libs Thread::Threads)
+    list(APPEND libs ${CMAKE_DL_LIBS})
+endif() 
+
 include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -2,10 +2,8 @@
 
 if ( CMAKE_HOST_UNIX AND NOT MINGW ) 
     find_package(Threads REQUIRED)
-    message("Using threads: " ${Threads::Threads})
-    message("Using threads: " ${CMAKE_DL_LIBS})
-    list(APPEND libs Threads::Threads)
-    list(APPEND libs ${CMAKE_DL_LIBS})
+    add_library(Threads::Threads)
+    add_library(${CMAKE_DL_LIBS})
 endif() 
 
 include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -2,7 +2,8 @@
 
 if ( CMAKE_HOST_UNIX AND NOT MINGW ) 
     find_package(Threads REQUIRED)
-    message("Using threads: " Threads::Threads)
+    message("Using threads: " ${Threads::Threads})
+    message("Using threads: " ${CMAKE_DL_LIBS})
     list(APPEND libs Threads::Threads)
     list(APPEND libs ${CMAKE_DL_LIBS})
 endif() 

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,6 +1,6 @@
 @PACKAGE_INIT@
 
-if ( CMAKE_HOST_UNIX AND NOT MINGW ) 
+if ( CMAKE_HOST_UNIX AND NOT (MINGW OR CYGWIN) ) 
     find_package(Threads REQUIRED)
 endif() 
 


### PR DESCRIPTION
Removed direct linkage to lib DL and pthread (for boost dependency).  

Improved export targets, naming.  
Dynamic link library STDLIB must be version-named due to hard-coded test dynamically loading it with dlopen. 